### PR TITLE
Moved derivative sigmoid and tanh into seperate functions

### DIFF
--- a/lstm.py
+++ b/lstm.py
@@ -6,10 +6,10 @@ import math
 def sigmoid(x): 
     return 1. / (1 + np.exp(-x))
 
-def sigmoid_inverse(values): 
+def sigmoid_derivative(values): 
     return values*(1-values)
 
-def tanh_inverse(values): 
+def tanh_derivative(values): 
     return 1. - values ** 2
 
 # createst uniform random array w/ values in [a,b) and shape args
@@ -111,10 +111,10 @@ class LstmNode:
         df = self.s_prev * ds
 
         # diffs w.r.t. vector inside sigma / tanh function
-        di_input = sigmoid_inverse(self.state.i) * di 
-        df_input = sigmoid_inverse(self.state.f) * df 
-        do_input = sigmoid_inverse(self.state.o) * do 
-        dg_input = tanh_inverse(self.state.g) * dg
+        di_input = sigmoid_derivative(self.state.i) * di 
+        df_input = sigmoid_derivative(self.state.f) * df 
+        do_input = sigmoid_derivative(self.state.o) * do 
+        dg_input = tanh_derivative(self.state.g) * dg
 
         # diffs w.r.t. inputs
         self.param.wi_diff += np.outer(di_input, self.xc)

--- a/lstm.py
+++ b/lstm.py
@@ -6,6 +6,12 @@ import math
 def sigmoid(x): 
     return 1. / (1 + np.exp(-x))
 
+def sigmoid_inverse(val): 
+    return val*(1-val)
+
+def tanh_inverse(val): 
+    return 1. - val ** 2
+
 # createst uniform random array w/ values in [a,b) and shape args
 def rand_arr(a, b, *args): 
     np.random.seed(0)
@@ -105,10 +111,10 @@ class LstmNode:
         df = self.s_prev * ds
 
         # diffs w.r.t. vector inside sigma / tanh function
-        di_input = (1. - self.state.i) * self.state.i * di 
-        df_input = (1. - self.state.f) * self.state.f * df 
-        do_input = (1. - self.state.o) * self.state.o * do 
-        dg_input = (1. - self.state.g ** 2) * dg
+        di_input = sigmoid_inverse(self.state.i) * di 
+        df_input = sigmoid_inverse(self.state.f) * df 
+        do_input = sigmoid_inverse(self.state.o) * do 
+        dg_input = tanh_inverse(self.state.g) * dg
 
         # diffs w.r.t. inputs
         self.param.wi_diff += np.outer(di_input, self.xc)

--- a/lstm.py
+++ b/lstm.py
@@ -6,11 +6,11 @@ import math
 def sigmoid(x): 
     return 1. / (1 + np.exp(-x))
 
-def sigmoid_inverse(val): 
-    return val*(1-val)
+def sigmoid_inverse(values): 
+    return values*(1-values)
 
-def tanh_inverse(val): 
-    return 1. - val ** 2
+def tanh_inverse(values): 
+    return 1. - values ** 2
 
 # createst uniform random array w/ values in [a,b) and shape args
 def rand_arr(a, b, *args): 


### PR DESCRIPTION
I struggled for a while understanding this part of the code:
```
i_input = (1. - self.state.i) * self.state.i * di 
df_input = (1. - self.state.f) * self.state.f * df 
do_input = (1. - self.state.o) * self.state.o * do 
dg_input = (1. - self.state.g ** 2) * dg
```

After a while puzzling at it, I was able to see that these notations included the derivative of a sigmoid and a tanh function. I think that adding the sigmoid_derivative and tanh_derivative function to the code makes it more clear for the viewer what is happening at that location (so I did exactly that). It is also consistent with the fact that there is a separate sigmoid function.