### PR TITLE
Nicer formatting for test.py output; PEP8

### DIFF
--- a/test.py
+++ b/test.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from lstm import LstmParam, LstmNetwork
 
+
 class ToyLossLayer:
     """
     Computes square loss with first element of hidden layer array.
@@ -16,28 +17,33 @@ class ToyLossLayer:
         diff[0] = 2 * (pred[0] - label)
         return diff
 
+
 def example_0():
     # learns to repeat simple sequence from random inputs
     np.random.seed(0)
 
-    # parameters for input data dimension and lstm cell count 
+    # parameters for input data dimension and lstm cell count
     mem_cell_ct = 100
     x_dim = 50
-    lstm_param = LstmParam(mem_cell_ct, x_dim) 
+    lstm_param = LstmParam(mem_cell_ct, x_dim)
     lstm_net = LstmNetwork(lstm_param)
-    y_list = [-0.5,0.2,0.1, -0.5]
+    y_list = [-0.5, 0.2, 0.1, -0.5]
     input_val_arr = [np.random.random(x_dim) for _ in y_list]
 
     for cur_iter in range(100):
-        print("cur iter: " + str(cur_iter))
+        print("iter", "%2s" % str(cur_iter), end=": ")
         for ind in range(len(y_list)):
             lstm_net.x_list_add(input_val_arr[ind])
-            print("y_pred[" + str(ind) + "] : " + str(lstm_net.lstm_node_list[ind].state.h[0]))
+
+        print("y_pred = [" +
+              ", ".join(["% 2.5f" % lstm_net.lstm_node_list[ind].state.h[0] for ind in range(len(y_list))]) +
+              "]", end=", ")
 
         loss = lstm_net.y_list_is(y_list, ToyLossLayer)
-        print("loss: " + str(loss))
+        print("loss:", "%.3e" % loss)
         lstm_param.apply_diff(lr=0.1)
         lstm_net.x_list_clear()
+
 
 if __name__ == "__main__":
     example_0()


### PR DESCRIPTION
Tighter output for the test example - each iteration is on one line, and number are trimmed to a few siginificant figures.

Old:

```
cur iter: 98
y_pred[0] : -0.50034152006
y_pred[1] : 0.201122394088
y_pred[2] : 0.0990753171675
y_pred[3] : -0.499190430063
loss: 2.8868462645e-06
cur iter: 99
y_pred[0] : -0.500331437373
y_pred[1] : 0.201063161851
y_pred[2] : 0.0991220279374
y_pred[3] : -0.499225555158
loss: 2.61076361058e-06

```

New:

```
iter 98: y_pred = [-0.50034,  0.20112,  0.09908, -0.49919], loss: 2.887e-06
iter 99: y_pred = [-0.50033,  0.20106,  0.09912, -0.49923], loss: 2.611e-06
```

Also a couple of PEP8 clean ups.