### PR TITLE
Remove incorrect var `top_diff_s` in derivative

### DIFF
--- a/lstm.py
+++ b/lstm.py
@@ -99,9 +99,9 @@ class LstmNode:
 
         self.xc = xc
     
-    def top_diff_is(self, top_diff_h, top_diff_s):
+    def top_diff_is(self, top_diff_h):
         # notice that top_diff_s is carried along the constant error carousel
-        ds = self.state.o * top_diff_h + top_diff_s
+        ds = self.state.o * top_diff_h
         do = self.state.s * top_diff_h
         di = self.state.g * ds
         dg = self.state.i * ds
@@ -153,9 +153,7 @@ class LstmNetwork():
         # first node only gets diffs from label ...
         loss = loss_layer.loss(self.lstm_node_list[idx].state.h, y_list[idx])
         diff_h = loss_layer.bottom_diff(self.lstm_node_list[idx].state.h, y_list[idx])
-        # here s is not affecting loss due to h(t+1), hence we set equal to zero
-        diff_s = np.zeros(self.lstm_param.mem_cell_ct)
-        self.lstm_node_list[idx].top_diff_is(diff_h, diff_s)
+        self.lstm_node_list[idx].top_diff_is(diff_h)
         idx -= 1
 
         ### ... following nodes also get diffs from next nodes, hence we add diffs to diff_h
@@ -164,8 +162,7 @@ class LstmNetwork():
             loss += loss_layer.loss(self.lstm_node_list[idx].state.h, y_list[idx])
             diff_h = loss_layer.bottom_diff(self.lstm_node_list[idx].state.h, y_list[idx])
             diff_h += self.lstm_node_list[idx + 1].state.bottom_diff_h
-            diff_s = self.lstm_node_list[idx + 1].state.bottom_diff_s
-            self.lstm_node_list[idx].top_diff_is(diff_h, diff_s)
+            self.lstm_node_list[idx].top_diff_is(diff_h)
             idx -= 1 
 
         return loss


### PR DESCRIPTION
The derivative `ds` was calculated incorrectly. I removed the wrong variable `top_diff_s` in this PR. After removing the variable and testing the example, the loss is significantly lower than before after training. 

Output Before Change:
`iter 99: y_pred = [-0.50033,  0.20106,  0.09912, -0.49923], loss: 2.611e-06`
Output After Change:
`iter 99: y_pred = [-0.49995,  0.19999,  0.10001, -0.50006], loss: 6.078e-09`